### PR TITLE
Update requirements.txt

### DIFF
--- a/torch-neuronx/training/dp_bert_hf_pretrain/requirements.txt
+++ b/torch-neuronx/training/dp_bert_hf_pretrain/requirements.txt
@@ -10,3 +10,4 @@ sentencepiece != 0.1.92
 protobuf
 h5py
 requests
+numpy<=1.20.0


### PR DESCRIPTION
Pin numpy to <=1.20.0. This is the constraint that's already in neuronx-cc, but since pip does not have consistency checking this file stomps all over that.