### PR TITLE
Adding deprecated to megatron LM link and adding Nemo Link for 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Samples are organized by use case (training, inference) and deep learning framew
 | Usage | Description | Instance Type |
 | --- | --- | --- |
 | [Megatron-LM for Neuron (DEPRECATED)](https://github.com/aws-neuron/aws-neuron-reference-for-megatron-lm) | A library that enables large-scale distributed training of language models such as GPT and is adapted from Megatron-LM. | Trn1, Trn1n |
-| [Nemo Megatron for Neuron]([(https://github.com/aws-neuron/neuronx-nemo-megatron]) | A library that enables large-scale distributed training of language models such as Llama and is adapted from Nemo Megatron. | Trn1, Trn1n |
+| [Nemo Megatron for Neuron](https://github.com/aws-neuron/neuronx-nemo-megatron) | A library that enables large-scale distributed training of language models such as Llama and is adapted from Nemo Megatron. | Trn1, Trn1n |
 | [AWS Neuron samples for ParallelCluster](https://github.com/aws-neuron/aws-neuron-parallelcluster-samples) | How to use AWS ParallelCluster to build HPC compute cluster that uses trn1 compute nodes to run your distributed ML training job.  | Trn1, Trn1n |
 | [AWS Neuron samples for EKS](https://github.com/aws-neuron/aws-neuron-eks-samples) | The samples in this repository demonstrate the types of patterns that can be used to deliver inference and distributed training on EKS using Inferentia and Trainium. | Trn1, Trn1n |
 | [AWS Neuron samples for SageMaker](https://github.com/aws-neuron/aws-neuron-sagemaker-samples) | SageMaker Samples using ml.trn1 instances for machine learning (ML) training workloads on the AWS ML accelerator chips Trainium. | Trn1, Trn1n |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Samples are organized by use case (training, inference) and deep learning framew
 
 | Usage | Description | Instance Type |
 | --- | --- | --- |
-| [Megatron-LM for Neuron](https://github.com/aws-neuron/aws-neuron-reference-for-megatron-lm) | A library that enables large-scale distributed training of language models such as GPT and is adapted from Megatron-LM. | Trn1, Trn1n |
+| [Megatron-LM for Neuron (DEPRECATED)](https://github.com/aws-neuron/aws-neuron-reference-for-megatron-lm) | A library that enables large-scale distributed training of language models such as GPT and is adapted from Megatron-LM. | Trn1, Trn1n |
+| [Nemo Megatron for Neuron]([(https://github.com/aws-neuron/neuronx-nemo-megatron]) | A library that enables large-scale distributed training of language models such as Llama and is adapted from Nemo Megatron. | Trn1, Trn1n |
 | [AWS Neuron samples for ParallelCluster](https://github.com/aws-neuron/aws-neuron-parallelcluster-samples) | How to use AWS ParallelCluster to build HPC compute cluster that uses trn1 compute nodes to run your distributed ML training job.  | Trn1, Trn1n |
 | [AWS Neuron samples for EKS](https://github.com/aws-neuron/aws-neuron-eks-samples) | The samples in this repository demonstrate the types of patterns that can be used to deliver inference and distributed training on EKS using Inferentia and Trainium. | Trn1, Trn1n |
 | [AWS Neuron samples for SageMaker](https://github.com/aws-neuron/aws-neuron-sagemaker-samples) | SageMaker Samples using ml.trn1 instances for machine learning (ML) training workloads on the AWS ML accelerator chips Trainium. | Trn1, Trn1n |


### PR DESCRIPTION
As per deprecation plan: https://quip-amazon.com/DDFGA7HreQ2r/Deprecation-plan-for-Megatron-LM-and-moving-to-Nemo-Megatron