### PR TITLE
fix: typo in sdxl base+refiner

### DIFF
--- a/torch-neuronx/inference/hf_pretrained_sdxl_base_and_refiner_1024_inference.ipynb
+++ b/torch-neuronx/inference/hf_pretrained_sdxl_base_and_refiner_1024_inference.ipynb
@@ -481,7 +481,7 @@
                 "#     plt.xlabel(\"X pixel scaling\")\n",
                 "#     plt.ylabel(\"Y pixels scaling\")\n",
                 "\n",
-                "#     image = mpimg.imread(\"image.png\")\n",
+                "#     image = mpimg.imread(\"image2.png\")\n",
                 "#     plt.imshow(image)\n",
                 "#     plt.show()\n",
                 "#     print(\"time: \", np.round(total_time, 2), \"seconds\")\n"


### PR DESCRIPTION
in the last section, wrong image is used for imshow. slightly confusing while following through the tutorial