### PR TITLE
use multi processing for large datasets

### DIFF
--- a/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/get_dataset.py
+++ b/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/get_dataset.py
@@ -2,6 +2,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer
 from itertools import chain
 import os
+import multiprocessing
 
 dataset_name = "wikicorpus"
 dataset_config_name = "raw_en"
@@ -57,11 +58,12 @@ lm_datasets = tokenized_datasets.map(
     group_texts,
     batched=True,
     load_from_cache_file=True,
+    num_proc=max(multiprocessing.cpu_count(), 1),
     desc=f"Grouping texts in chunks of {block_size}",
 )
 
 train_dataset = lm_datasets["train"]
 print(len(train_dataset))
 
-train_dataset.save_to_disk(save_path)
+train_dataset.save_to_disk(save_path, num_proc=max(multiprocessing.cpu_count(), 1))
 


### PR DESCRIPTION
The current code results in pretty slow of grouping and saving of text if the dataset is large.

I have run the test against wiki dataset to confirm the change works.

#Test
python3.8 get_dataset.py
 Running tokenizer on dataset:   0%|                                                                                                                             | 0/1359146 
Running tokenizer on dataset: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1359146/1359146 [07:39<00:00, 2959.40 examples/s]
block_size > tokenizer.model_max_length
Grouping texts in chunks of 512 (num_proc=8): 100%|████████████████████████████████████████████████████████████████████████████████████████████|
1641875
Saving the dataset (22/22 shards): 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████|  