### PR TITLE
Bug fix: use load_sharded_state_dict for NeuronZero1Optimizer

### DIFF
--- a/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/get_dataset.py
+++ b/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/get_dataset.py
@@ -2,6 +2,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer
 from itertools import chain
 import os
+import multiprocessing
 
 dataset_name = "wikicorpus"
 dataset_config_name = "raw_en"
@@ -57,11 +58,12 @@ lm_datasets = tokenized_datasets.map(
     group_texts,
     batched=True,
     load_from_cache_file=True,
+    num_proc=max(multiprocessing.cpu_count(), 1),
     desc=f"Grouping texts in chunks of {block_size}",
 )
 
 train_dataset = lm_datasets["train"]
 print(len(train_dataset))
 
-train_dataset.save_to_disk(save_path)
+train_dataset.save_to_disk(save_path, num_proc=max(multiprocessing.cpu_count(), 1))
 

--- a/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/tp_zero1_llama2_7b_hf_pretrain.py
+++ b/torch-neuronx/training/tp_zero1_llama2_7b_hf_pretrain/tp_zero1_llama2_7b_hf_pretrain.py
@@ -287,7 +287,7 @@ def get_dtype(model) -> str:
             return "torch.bfloat16"
         if "torch.double" in str(model.dtype):
             return "torch.float32"
-    return str(model.dtype)    
+    return str(model.dtype)
 
 def allreduce_sequence_parallel_gradients(optimizer):
     """ All-reduce layernorm parameters across model parallel nodes when sequence parallelism is used.
@@ -482,7 +482,7 @@ def train_llama(flags):
 
     if flags.resume_ckpt:
         state_dict = checkpointing.load(flags.output_dir, model)
-        optimizer.load_state_dict(state_dict["optimizer"])
+        optimizer.load_sharded_state_dict(flags.output_dir)
         global_step = state_dict["global_step"]
         epoch = state_dict["epoch"]
         scheduler_state_dict = state_dict["scheduler"]


### PR DESCRIPTION
1. optimizer states are checkpointed via `load_sharded_state_dict`.
2. The current tries to load it from state_dictionary resulting in key error.
```
Traceback (most recent call last):
  File "tp_zero1_llama2_7b_hf_pretrain.py", line 838, in <module>
    _mp_fn(0, args)
  File "tp_zero1_llama2_7b_hf_pretrain.py", line 711, in _mp_fn
Traceback (most recent call last):
  File "tp_zero1_llama2_7b_hf_pretrain.py", line 838, in <module>
    train_llama(flags)
  File "tp_zero1_llama2_7b_hf_pretrain.py", line 538, in train_llama
    optimizer.load_state_dict(state_dict["optimizer"])
KeyError: 'optimizer'
```
3. With change I was able to resume training
```
............

Compiler status PASS
LOG Thu Oct 12 22:12:27 2023 - (0, 101) step_loss : 1.0938  throughput : 0.66
global step = 101
```