### PR TITLE
Add a note regarding the dataset used in the ViT training tutorial

### DIFF
--- a/torch-neuronx/training/hf_image_classification/vit.ipynb
+++ b/torch-neuronx/training/hf_image_classification/vit.ipynb
@@ -1,207 +1,216 @@
 {
-    "cells": [
-        {
-            "attachments": {},
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# Vision Transformer - Pytorch\n",
-                "This notebook shows how to fine-tune a pretrained HuggingFace vision transformer PyTorch model with AWS Trainium (trn1 instances) using NeuronSDK.\n",
-                "The original implementation is provided by HuggingFace.\n",
-                "\n",
-                "The example has 2 stages:\n",
-                "1. First compile the model using the utility `neuron_parallel_compile` to compile the model to run on the AWS Trainium device.\n",
-                "1. Run the fine-tuning script to train the model based on image classification task. The training job will use 32 workers with data parallel to speed up the training.\n",
-                "\n",
-                "It has been tested and run on a trn1.2xlarge and trn1.32xlarge\n",
-                "\n",
-                "**Reference:** https://huggingface.co/google/vit-base-patch16-224"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 1) Install dependencies"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "Verify that this Jupyter notebook is running the Python kernel environment that was set up according to the [PyTorch Installation Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx). You can select the kernel from the 'Kernel -> Change Kernel' option on the top of this Jupyter notebook page."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%env TOKENIZERS_PARALLELISM=True #Supresses tokenizer warnings making errors easier to detect\n",
-                "#Install Neuron Compiler and Neuron/XLA packages\n",
-                "%pip install -U \"protobuf<4\" \"transformers==4.40.1\" \"numpy==1.24.4\" optimum-neuron datasets evaluate scikit-learn \n",
-                "%pip install -U \"accelerate==0.27.2\"\n",
-                "# use --force-reinstall if you're facing some issues while loading the modules\n",
-                "# now restart the kernel again"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 2) Set the parameters"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Parameters\n",
-                "model_name = \"google/vit-base-patch16-224-in21k\"\n",
-                "env_var_options = \"NEURON_RT_ASYNC_EXEC_MAX_INFLIGHT_REQUESTS=3 MALLOC_ARENA_MAX=64 XLA_USE_BF16=1 NEURON_CC_FLAGS=\\\"--model-type=transformer --cache_dir=./compiler_cache\\\"\"\n",
-                "num_workers = 32\n",
-                "task_name = \"image-classification\"\n",
-                "dataset_name = \"cifar10\"\n",
-                "transformers_version = \"4.28.1\"\n",
-                "model_base_name = \"vit\"\n",
-                "# The default batch size 64 will give the best training throughput but will lead to slower compilation.\n",
-                "# If you want to speed up the compilation, use smaller batch size like 48, 32, etc.\n",
-                "per_device_train_batch_size = 64\n",
-                "per_device_eval_batch_size = 64\n",
-                "# Number of graphs being compiled in parallel. It's possible to use 8 for smaller train batch sizes\n",
-                "# to boost compilation process, but increasing it can be flakey and can cause compilation failures.\n",
-                "num_parallel_compile = 4\n",
-                "learning_rate = 2e-5\n",
-                "dataloader_num_workers = 2\n",
-                "device_prefetch_size = 2\n",
-                "host_to_device_transfer_threads = 4"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 3) Compile the model with neuron_parallel_compile"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%%time\n",
-                "import subprocess\n",
-                "print(\"Compile model\")\n",
-                "COMPILE_CMD = f\"\"\"{env_var_options} neuron_parallel_compile --num_parallel={num_parallel_compile} torchrun --nproc_per_node={num_workers} \\\n",
-                "    run_image_classification.py \\\n",
-                "    --model_name_or_path {model_name} \\\n",
-                "    --dataset_name {dataset_name} \\\n",
-                "    --do_train \\\n",
-                "    --max_steps 10 \\\n",
-                "    --num_train_epochs 10 \\\n",
-                "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
-                "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
-                "    --learning_rate {learning_rate} \\\n",
-                "    --learning_rate 2e-5 \\\n",
-                "    --save_strategy epoch \\\n",
-                "    --save_total_limit 1 \\\n",
-                "    --seed 1337 \\\n",
-                "    --remove_unused_columns False \\\n",
-                "    --overwrite_output_dir \\\n",
-                "    --output_dir {model_base_name}-{task_name} \\\n",
-                "    --dataloader_num_workers {dataloader_num_workers} \\\n",
-                "    --ignore_mismatched_sizes \\\n",
-                "    --device_prefetch_size {device_prefetch_size} \\\n",
-                "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
-                "\n",
-                "print(f'Running command: \\n{COMPILE_CMD}')\n",
-                "if subprocess.check_call(COMPILE_CMD,shell=True):\n",
-                "   print(\"There was an error with the compilation command\")\n",
-                "else:\n",
-                "   print(\"Compilation Success!!!\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "## 4) Fine-tune the model"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {
-                "vscode": {
-                    "languageId": "shellscript"
-                }
-            },
-            "outputs": [],
-            "source": [
-                "%%time\n",
-                "print(\"Train model\")\n",
-                "RUN_CMD = f\"\"\"{env_var_options} torchrun --nproc_per_node={num_workers} \\\n",
-                "    run_image_classification.py \\\n",
-                "    --model_name_or_path {model_name} \\\n",
-                "    --dataset_name {dataset_name} \\\n",
-                "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
-                "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
-                "    --do_train \\\n",
-                "    --do_eval \\\n",
-                "    --remove_unused_columns False \\\n",
-                "    --learning_rate {learning_rate} \\\n",
-                "    --num_train_epochs 10 \\\n",
-                "    --logging_strategy steps \\\n",
-                "    --logging_steps 10 \\\n",
-                "    --evaluation_strategy epoch \\\n",
-                "    --save_strategy epoch \\\n",
-                "    --load_best_model_at_end True \\\n",
-                "    --save_total_limit 3 \\\n",
-                "    --seed 1337 \\\n",
-                "    --overwrite_output_dir \\\n",
-                "    --output_dir {model_base_name}-{task_name} \\\n",
-                "    --dataloader_num_workers {dataloader_num_workers} \\\n",
-                "    --ignore_mismatched_sizes \\\n",
-                "    --device_prefetch_size {device_prefetch_size} \\\n",
-                "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
-                "\n",
-                "print(f'Running command: \\n{RUN_CMD}')\n",
-                "if subprocess.check_call(RUN_CMD,shell=True):\n",
-                "   print(\"There was an error with the fine-tune command\")\n",
-                "else:\n",
-                "   print(\"Fine-tune Successful!!!\")"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python (torch-neuronx)",
-            "language": "python",
-            "name": "aws_neuron_venv_pytorch"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.8.10"
-        },
-        "orig_nbformat": 4,
-        "vscode": {
-            "interpreter": {
-                "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
-            }
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 2
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Vision Transformer - Pytorch\n",
+    "This notebook shows how to fine-tune a pretrained HuggingFace vision transformer PyTorch model with AWS Trainium (trn1 instances) using NeuronSDK.\n",
+    "The original implementation is provided by HuggingFace.\n",
+    "\n",
+    "The example has 2 stages:\n",
+    "1. First compile the model using the utility `neuron_parallel_compile` to compile the model to run on the AWS Trainium device.\n",
+    "1. Run the fine-tuning script to train the model based on image classification task. The training job will use 32 workers with data parallel to speed up the training.\n",
+    "\n",
+    "It has been tested and run on a trn1.2xlarge and trn1.32xlarge\n",
+    "\n",
+    "**Reference:** https://huggingface.co/google/vit-base-patch16-224"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Verify that this Jupyter notebook is running the Python kernel environment that was set up according to the [PyTorch Installation Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx). You can select the kernel from the 'Kernel -> Change Kernel' option on the top of this Jupyter notebook page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%env TOKENIZERS_PARALLELISM=True #Supresses tokenizer warnings making errors easier to detect\n",
+    "#Install Neuron Compiler and Neuron/XLA packages\n",
+    "%pip install -U \"protobuf<4\" \"transformers==4.40.1\" \"numpy==1.24.4\" optimum-neuron datasets evaluate scikit-learn \n",
+    "%pip install -U \"accelerate==0.27.2\"\n",
+    "# use --force-reinstall if you're facing some issues while loading the modules\n",
+    "# now restart the kernel again"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Set the parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "model_name = \"google/vit-base-patch16-224-in21k\"\n",
+    "env_var_options = \"NEURON_RT_ASYNC_EXEC_MAX_INFLIGHT_REQUESTS=3 MALLOC_ARENA_MAX=64 XLA_USE_BF16=1 NEURON_CC_FLAGS=\\\"--model-type=transformer --cache_dir=./compiler_cache\\\"\"\n",
+    "num_workers = 32\n",
+    "task_name = \"image-classification\"\n",
+    "dataset_name = \"cifar10\"\n",
+    "transformers_version = \"4.28.1\"\n",
+    "model_base_name = \"vit\"\n",
+    "# The default batch size 64 will give the best training throughput but will lead to slower compilation.\n",
+    "# If you want to speed up the compilation, use smaller batch size like 48, 32, etc.\n",
+    "per_device_train_batch_size = 64\n",
+    "per_device_eval_batch_size = 64\n",
+    "# Number of graphs being compiled in parallel. It's possible to use 8 for smaller train batch sizes\n",
+    "# to boost compilation process, but increasing it can be flakey and can cause compilation failures.\n",
+    "num_parallel_compile = 4\n",
+    "learning_rate = 2e-5\n",
+    "dataloader_num_workers = 2\n",
+    "device_prefetch_size = 2\n",
+    "host_to_device_transfer_threads = 4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Note: To observe more stable throughputs, a longer training job with a dataset larger than CIFAR-10 is needed."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Compile the model with neuron_parallel_compile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import subprocess\n",
+    "print(\"Compile model\")\n",
+    "COMPILE_CMD = f\"\"\"{env_var_options} neuron_parallel_compile --num_parallel={num_parallel_compile} torchrun --nproc_per_node={num_workers} \\\n",
+    "    run_image_classification.py \\\n",
+    "    --model_name_or_path {model_name} \\\n",
+    "    --dataset_name {dataset_name} \\\n",
+    "    --do_train \\\n",
+    "    --max_steps 10 \\\n",
+    "    --num_train_epochs 10 \\\n",
+    "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
+    "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
+    "    --learning_rate {learning_rate} \\\n",
+    "    --learning_rate 2e-5 \\\n",
+    "    --save_strategy epoch \\\n",
+    "    --save_total_limit 1 \\\n",
+    "    --seed 1337 \\\n",
+    "    --remove_unused_columns False \\\n",
+    "    --overwrite_output_dir \\\n",
+    "    --output_dir {model_base_name}-{task_name} \\\n",
+    "    --dataloader_num_workers {dataloader_num_workers} \\\n",
+    "    --ignore_mismatched_sizes \\\n",
+    "    --device_prefetch_size {device_prefetch_size} \\\n",
+    "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
+    "\n",
+    "print(f'Running command: \\n{COMPILE_CMD}')\n",
+    "if subprocess.check_call(COMPILE_CMD,shell=True):\n",
+    "   print(\"There was an error with the compilation command\")\n",
+    "else:\n",
+    "   print(\"Compilation Success!!!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4) Fine-tune the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "print(\"Train model\")\n",
+    "RUN_CMD = f\"\"\"{env_var_options} torchrun --nproc_per_node={num_workers} \\\n",
+    "    run_image_classification.py \\\n",
+    "    --model_name_or_path {model_name} \\\n",
+    "    --dataset_name {dataset_name} \\\n",
+    "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
+    "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
+    "    --do_train \\\n",
+    "    --do_eval \\\n",
+    "    --remove_unused_columns False \\\n",
+    "    --learning_rate {learning_rate} \\\n",
+    "    --num_train_epochs 10 \\\n",
+    "    --logging_strategy steps \\\n",
+    "    --logging_steps 10 \\\n",
+    "    --evaluation_strategy epoch \\\n",
+    "    --save_strategy epoch \\\n",
+    "    --load_best_model_at_end True \\\n",
+    "    --save_total_limit 3 \\\n",
+    "    --seed 1337 \\\n",
+    "    --overwrite_output_dir \\\n",
+    "    --output_dir {model_base_name}-{task_name} \\\n",
+    "    --dataloader_num_workers {dataloader_num_workers} \\\n",
+    "    --ignore_mismatched_sizes \\\n",
+    "    --device_prefetch_size {device_prefetch_size} \\\n",
+    "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
+    "\n",
+    "print(f'Running command: \\n{RUN_CMD}')\n",
+    "if subprocess.check_call(RUN_CMD,shell=True):\n",
+    "   print(\"There was an error with the fine-tune command\")\n",
+    "else:\n",
+    "   print(\"Fine-tune Successful!!!\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (torch-neuronx)",
+   "language": "python",
+   "name": "aws_neuron_venv_pytorch"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/torch-neuronx/training/hf_image_classification/vit.ipynb
+++ b/torch-neuronx/training/hf_image_classification/vit.ipynb
@@ -1,216 +1,214 @@
 {
- "cells": [
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Vision Transformer - Pytorch\n",
-    "This notebook shows how to fine-tune a pretrained HuggingFace vision transformer PyTorch model with AWS Trainium (trn1 instances) using NeuronSDK.\n",
-    "The original implementation is provided by HuggingFace.\n",
-    "\n",
-    "The example has 2 stages:\n",
-    "1. First compile the model using the utility `neuron_parallel_compile` to compile the model to run on the AWS Trainium device.\n",
-    "1. Run the fine-tuning script to train the model based on image classification task. The training job will use 32 workers with data parallel to speed up the training.\n",
-    "\n",
-    "It has been tested and run on a trn1.2xlarge and trn1.32xlarge\n",
-    "\n",
-    "**Reference:** https://huggingface.co/google/vit-base-patch16-224"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 1) Install dependencies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Verify that this Jupyter notebook is running the Python kernel environment that was set up according to the [PyTorch Installation Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx). You can select the kernel from the 'Kernel -> Change Kernel' option on the top of this Jupyter notebook page."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%env TOKENIZERS_PARALLELISM=True #Supresses tokenizer warnings making errors easier to detect\n",
-    "#Install Neuron Compiler and Neuron/XLA packages\n",
-    "%pip install -U \"protobuf<4\" \"transformers==4.40.1\" \"numpy==1.24.4\" optimum-neuron datasets evaluate scikit-learn \n",
-    "%pip install -U \"accelerate==0.27.2\"\n",
-    "# use --force-reinstall if you're facing some issues while loading the modules\n",
-    "# now restart the kernel again"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2) Set the parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Parameters\n",
-    "model_name = \"google/vit-base-patch16-224-in21k\"\n",
-    "env_var_options = \"NEURON_RT_ASYNC_EXEC_MAX_INFLIGHT_REQUESTS=3 MALLOC_ARENA_MAX=64 XLA_USE_BF16=1 NEURON_CC_FLAGS=\\\"--model-type=transformer --cache_dir=./compiler_cache\\\"\"\n",
-    "num_workers = 32\n",
-    "task_name = \"image-classification\"\n",
-    "dataset_name = \"cifar10\"\n",
-    "transformers_version = \"4.28.1\"\n",
-    "model_base_name = \"vit\"\n",
-    "# The default batch size 64 will give the best training throughput but will lead to slower compilation.\n",
-    "# If you want to speed up the compilation, use smaller batch size like 48, 32, etc.\n",
-    "per_device_train_batch_size = 64\n",
-    "per_device_eval_batch_size = 64\n",
-    "# Number of graphs being compiled in parallel. It's possible to use 8 for smaller train batch sizes\n",
-    "# to boost compilation process, but increasing it can be flakey and can cause compilation failures.\n",
-    "num_parallel_compile = 4\n",
-    "learning_rate = 2e-5\n",
-    "dataloader_num_workers = 2\n",
-    "device_prefetch_size = 2\n",
-    "host_to_device_transfer_threads = 4"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "Note: To observe more stable throughputs, a longer training job with a dataset larger than CIFAR-10 is needed."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3) Compile the model with neuron_parallel_compile"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "import subprocess\n",
-    "print(\"Compile model\")\n",
-    "COMPILE_CMD = f\"\"\"{env_var_options} neuron_parallel_compile --num_parallel={num_parallel_compile} torchrun --nproc_per_node={num_workers} \\\n",
-    "    run_image_classification.py \\\n",
-    "    --model_name_or_path {model_name} \\\n",
-    "    --dataset_name {dataset_name} \\\n",
-    "    --do_train \\\n",
-    "    --max_steps 10 \\\n",
-    "    --num_train_epochs 10 \\\n",
-    "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
-    "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
-    "    --learning_rate {learning_rate} \\\n",
-    "    --learning_rate 2e-5 \\\n",
-    "    --save_strategy epoch \\\n",
-    "    --save_total_limit 1 \\\n",
-    "    --seed 1337 \\\n",
-    "    --remove_unused_columns False \\\n",
-    "    --overwrite_output_dir \\\n",
-    "    --output_dir {model_base_name}-{task_name} \\\n",
-    "    --dataloader_num_workers {dataloader_num_workers} \\\n",
-    "    --ignore_mismatched_sizes \\\n",
-    "    --device_prefetch_size {device_prefetch_size} \\\n",
-    "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
-    "\n",
-    "print(f'Running command: \\n{COMPILE_CMD}')\n",
-    "if subprocess.check_call(COMPILE_CMD,shell=True):\n",
-    "   print(\"There was an error with the compilation command\")\n",
-    "else:\n",
-    "   print(\"Compilation Success!!!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4) Fine-tune the model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "shellscript"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "print(\"Train model\")\n",
-    "RUN_CMD = f\"\"\"{env_var_options} torchrun --nproc_per_node={num_workers} \\\n",
-    "    run_image_classification.py \\\n",
-    "    --model_name_or_path {model_name} \\\n",
-    "    --dataset_name {dataset_name} \\\n",
-    "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
-    "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
-    "    --do_train \\\n",
-    "    --do_eval \\\n",
-    "    --remove_unused_columns False \\\n",
-    "    --learning_rate {learning_rate} \\\n",
-    "    --num_train_epochs 10 \\\n",
-    "    --logging_strategy steps \\\n",
-    "    --logging_steps 10 \\\n",
-    "    --evaluation_strategy epoch \\\n",
-    "    --save_strategy epoch \\\n",
-    "    --load_best_model_at_end True \\\n",
-    "    --save_total_limit 3 \\\n",
-    "    --seed 1337 \\\n",
-    "    --overwrite_output_dir \\\n",
-    "    --output_dir {model_base_name}-{task_name} \\\n",
-    "    --dataloader_num_workers {dataloader_num_workers} \\\n",
-    "    --ignore_mismatched_sizes \\\n",
-    "    --device_prefetch_size {device_prefetch_size} \\\n",
-    "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
-    "\n",
-    "print(f'Running command: \\n{RUN_CMD}')\n",
-    "if subprocess.check_call(RUN_CMD,shell=True):\n",
-    "   print(\"There was an error with the fine-tune command\")\n",
-    "else:\n",
-    "   print(\"Fine-tune Successful!!!\")\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python (torch-neuronx)",
-   "language": "python",
-   "name": "aws_neuron_venv_pytorch"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
-  },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "cells": [
+        {
+            "attachments": {},
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# Vision Transformer - Pytorch\n",
+                "This notebook shows how to fine-tune a pretrained HuggingFace vision transformer PyTorch model with AWS Trainium (trn1 instances) using NeuronSDK.\n",
+                "The original implementation is provided by HuggingFace.\n",
+                "\n",
+                "The example has 2 stages:\n",
+                "1. First compile the model using the utility `neuron_parallel_compile` to compile the model to run on the AWS Trainium device.\n",
+                "1. Run the fine-tuning script to train the model based on image classification task. The training job will use 32 workers with data parallel to speed up the training.\n",
+                "\n",
+                "It has been tested and run on a trn1.2xlarge and trn1.32xlarge\n",
+                "\n",
+                "**Reference:** https://huggingface.co/google/vit-base-patch16-224"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## 1) Install dependencies"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Verify that this Jupyter notebook is running the Python kernel environment that was set up according to the [PyTorch Installation Guide](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/setup/torch-neuronx.html#setup-torch-neuronx). You can select the kernel from the 'Kernel -> Change Kernel' option on the top of this Jupyter notebook page."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "%env TOKENIZERS_PARALLELISM=True #Supresses tokenizer warnings making errors easier to detect\n",
+                "#Install Neuron Compiler and Neuron/XLA packages\n",
+                "%pip install -U \"protobuf<4\" \"transformers==4.40.1\" \"numpy==1.24.4\" optimum-neuron datasets evaluate scikit-learn \n",
+                "%pip install -U \"accelerate==0.27.2\"\n",
+                "# use --force-reinstall if you're facing some issues while loading the modules\n",
+                "# now restart the kernel again"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## 2) Set the parameters"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Parameters\n",
+                "model_name = \"google/vit-base-patch16-224-in21k\"\n",
+                "env_var_options = \"NEURON_RT_ASYNC_EXEC_MAX_INFLIGHT_REQUESTS=3 MALLOC_ARENA_MAX=64 XLA_USE_BF16=1 NEURON_CC_FLAGS=\\\"--model-type=transformer --cache_dir=./compiler_cache\\\"\"\n",
+                "num_workers = 32\n",
+                "task_name = \"image-classification\"\n",
+                "dataset_name = \"cifar10\"\n",
+                "transformers_version = \"4.28.1\"\n",
+                "model_base_name = \"vit\"\n",
+                "# The default batch size 64 will give the best training throughput but will lead to slower compilation.\n",
+                "# If you want to speed up the compilation, use smaller batch size like 48, 32, etc.\n",
+                "per_device_train_batch_size = 64\n",
+                "per_device_eval_batch_size = 64\n",
+                "# Number of graphs being compiled in parallel. It's possible to use 8 for smaller train batch sizes\n",
+                "# to boost compilation process, but increasing it can be flakey and can cause compilation failures.\n",
+                "num_parallel_compile = 4\n",
+                "learning_rate = 2e-5\n",
+                "dataloader_num_workers = 2\n",
+                "device_prefetch_size = 2\n",
+                "host_to_device_transfer_threads = 4"
+            ]
+        },
+        {
+           "cell_type": "markdown",
+            "metadata": {},
+           "source": [
+            "Note: To observe more stable throughputs, a longer training job with a dataset larger than CIFAR-10 is needed."
+           ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## 3) Compile the model with neuron_parallel_compile"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "%%time\n",
+                "import subprocess\n",
+                "print(\"Compile model\")\n",
+                "COMPILE_CMD = f\"\"\"{env_var_options} neuron_parallel_compile --num_parallel={num_parallel_compile} torchrun --nproc_per_node={num_workers} \\\n",
+                "    run_image_classification.py \\\n",
+                "    --model_name_or_path {model_name} \\\n",
+                "    --dataset_name {dataset_name} \\\n",
+                "    --do_train \\\n",
+                "    --max_steps 10 \\\n",
+                "    --num_train_epochs 10 \\\n",
+                "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
+                "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
+                "    --learning_rate {learning_rate} \\\n",
+                "    --learning_rate 2e-5 \\\n",
+                "    --save_strategy epoch \\\n",
+                "    --save_total_limit 1 \\\n",
+                "    --seed 1337 \\\n",
+                "    --remove_unused_columns False \\\n",
+                "    --overwrite_output_dir \\\n",
+                "    --output_dir {model_base_name}-{task_name} \\\n",
+                "    --dataloader_num_workers {dataloader_num_workers} \\\n",
+                "    --ignore_mismatched_sizes \\\n",
+                "    --device_prefetch_size {device_prefetch_size} \\\n",
+                "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
+                "\n",
+                "print(f'Running command: \\n{COMPILE_CMD}')\n",
+                "if subprocess.check_call(COMPILE_CMD,shell=True):\n",
+                "   print(\"There was an error with the compilation command\")\n",
+                "else:\n",
+                "   print(\"Compilation Success!!!\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "## 4) Fine-tune the model"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "vscode": {
+                    "languageId": "shellscript"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "%%time\n",
+                "print(\"Train model\")\n",
+                "RUN_CMD = f\"\"\"{env_var_options} torchrun --nproc_per_node={num_workers} \\\n",
+                "    run_image_classification.py \\\n",
+                "    --model_name_or_path {model_name} \\\n",
+                "    --dataset_name {dataset_name} \\\n",
+                "    --per_device_train_batch_size {per_device_train_batch_size} \\\n",
+                "    --per_device_eval_batch_size {per_device_eval_batch_size} \\\n",
+                "    --do_train \\\n",
+                "    --do_eval \\\n",
+                "    --remove_unused_columns False \\\n",
+                "    --learning_rate {learning_rate} \\\n",
+                "    --num_train_epochs 10 \\\n",
+                "    --logging_strategy steps \\\n",
+                "    --logging_steps 10 \\\n",
+                "    --evaluation_strategy epoch \\\n",
+                "    --save_strategy epoch \\\n",
+                "    --load_best_model_at_end True \\\n",
+                "    --save_total_limit 3 \\\n",
+                "    --seed 1337 \\\n",
+                "    --overwrite_output_dir \\\n",
+                "    --output_dir {model_base_name}-{task_name} \\\n",
+                "    --dataloader_num_workers {dataloader_num_workers} \\\n",
+                "    --ignore_mismatched_sizes \\\n",
+                "    --device_prefetch_size {device_prefetch_size} \\\n",
+                "    --host_to_device_transfer_threads {host_to_device_transfer_threads}\"\"\"\n",
+                "\n",
+                "print(f'Running command: \\n{RUN_CMD}')\n",
+                "if subprocess.check_call(RUN_CMD,shell=True):\n",
+                "   print(\"There was an error with the fine-tune command\")\n",
+                "else:\n",
+                "   print(\"Fine-tune Successful!!!\")"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python (torch-neuronx)",
+            "language": "python",
+            "name": "aws_neuron_venv_pytorch"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.8.10"
+        },
+        "orig_nbformat": 4,
+        "vscode": {
+            "interpreter": {
+                "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+            }
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
 }


### PR DESCRIPTION
*Description:*

We are using the CIFAR-10 dataset in the ViT tutorial. However, we found that the reported throughput could be unstable due to the small size of this dataset. Thus, while the tutorial is still valid, we add a note in this tutorial as a reminder that customers could use a larger dataset to observe more stable throughput numbers.