### PR TITLE
Fix (inference/vit test): change from list indexing to dictionary get in Neuron output

### DIFF
--- a/torch-neuronx/inference/hf_pretrained_vit_inference_on_inf2.ipynb
+++ b/torch-neuronx/inference/hf_pretrained_vit_inference_on_inf2.ipynb
@@ -134,18 +134,18 @@
                 "output_neuron = model_neuron(*example)\n",
                 "\n",
                 "# Compare the results\n",
-                "print(f\"CPU tensor:            {output_cpu[0][0][0:10]}\")\n",
-                "print(f\"Neuron tensor:         {output_neuron[0][0][0:10]}\")\n",
-                "print(f\"CPU classification:    {model.config.id2label[output_cpu[0].argmax(-1).item()]}\")\n",
-                "print(f\"Neuron classification: {model.config.id2label[output_neuron[0].argmax(-1).item()]}\")"
+                "print(f\"CPU tensor:            {output_cpu['logits'][0][0:10]}\")\n",
+                "print(f\"Neuron tensor:         {output_neuron['logits'][0][0:10]}\")\n",
+                "print(f\"CPU classification:    {model.config.id2label[output_cpu['logits'].argmax(-1).item()]}\")\n",
+                "print(f\"Neuron classification: {model.config.id2label[output_neuron['logits'].argmax(-1).item()]}\")"
             ]
         }
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": "Python (Neuron PyTorch)",
+            "display_name": "venv",
             "language": "python",
-            "name": "pytorch_venv"
+            "name": "python3"
         },
         "language_info": {
             "codemirror_mode": {
@@ -157,7 +157,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.8.10"
+            "version": "3.10.12"
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
This is to resolve an issue where the CPU output (`ImageClassifierOutput` type) is indexable, but Neuron output (`dict` type) is not.

The previous version of `hf_pretrained_vit_inference_on_inf2.ipynb` causes a KeyError: 
```
KeyError                                  Traceback (most recent call last)
Cell In[3], line 9
      7 # Compare the results
      8 print(f"CPU tensor:            {output_cpu[0][0][0:10]}")
----> 9 print(f"Neuron tensor:         {output_neuron[0][0][0:10]}")
     10 print(f"CPU classification:    {model.config.id2label[output_cpu[0].argmax(-1).item()]}")
     11 print(f"Neuron classification: {model.config.id2label[output_neuron[0].argmax(-1).item()]}")

KeyError: 0
```

New version output: 
```
CPU tensor:            tensor([-0.2744,  0.8215, -0.0836,  0.4159,  0.5623,  0.1859, -0.5773, -0.4600,
        -0.5339,  0.2402], grad_fn=<SliceBackward0>)
Neuron tensor:         tensor([-0.2744,  0.8215, -0.0836,  0.4159,  0.5623,  0.1859, -0.5773, -0.4600,
        -0.5339,  0.2402])
CPU classification:    Egyptian cat
Neuron classification: Egyptian cat
```