### PR TITLE
AppSec recommendation: Use an intermediate environment variable for in-line scripts

### DIFF
--- a/.github/workflows/aggregate-prs.yml
+++ b/.github/workflows/aggregate-prs.yml
@@ -24,41 +24,46 @@ jobs:
 
     - name: Check PR Labels and Merge for New Commit Events
       if: github.event.action == 'synchronize'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        LABELS_JSON=$(gh pr view ${{ github.event.pull_request.number }} --json labels)
+        LABELS_JSON=$(gh pr view "$PR_NUMBER" --json labels)
         LABELS=$(echo "$LABELS_JSON" | jq -r '.labels[].name')
         for LABEL_BRANCH in $LABELS; do
           # Check if the branch exists
-          if git show-ref --verify --quiet refs/heads/$LABEL_BRANCH; then
+          if git show-ref --verify --quiet "refs/heads/$LABEL_BRANCH"; then
             echo "Branch $LABEL_BRANCH already exists."
           else
             echo "Branch $LABEL_BRANCH does not exist, creating it."
-            git branch $LABEL_BRANCH origin/master
+            git branch "$LABEL_BRANCH" origin/master
           fi
-          git checkout $LABEL_BRANCH
-
+          git checkout "$LABEL_BRANCH"
+        
           # Merge PR changes into dynamic branch
-          git merge ${{ github.event.pull_request.head.sha }} --no-ff --no-commit
-          git commit -m "Merged PR #${{ github.event.pull_request.number }} due to new commits on labeled PR"
-          git push origin $LABEL_BRANCH
+          git merge "$PR_SHA" --no-ff --no-commit
+          git commit -m "Merged PR #${PR_NUMBER} due to new commits on labeled PR"
+          git push origin "$LABEL_BRANCH"
         done
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Merge for Labeled Event
       if: github.event.action == 'labeled'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
+        LABEL_BRANCH: ${{ github.event.label.name }}
       run: |
-        LABEL_BRANCH=${{ github.event.label.name }}
         # Check if the branch exists
-        if git show-ref --verify --quiet refs/heads/$LABEL_BRANCH; then
+        if git show-ref --verify --quiet "refs/heads/$LABEL_BRANCH"; then
           echo "Branch $LABEL_BRANCH already exists."
         else
           echo "Branch $LABEL_BRANCH does not exist, creating it."
-          git branch $LABEL_BRANCH origin/master
+          git branch "$LABEL_BRANCH" origin/master
         fi
-        git checkout $LABEL_BRANCH
-
+        git checkout "$LABEL_BRANCH"
+        
         # Merge PR changes into dynamic branch
-        git merge ${{ github.event.pull_request.head.sha }} --no-ff --no-commit
-        git commit -m "Merged PR #${{ github.event.pull_request.number }} due to label '$LABEL_BRANCH'"
-        git push origin $LABEL_BRANCH
+        git merge "$PR_SHA" --no-ff --no-commit
+        git commit -m "Merged PR #${PR_NUMBER} due to label '${LABEL_BRANCH}'"
+        git push origin "$LABEL_BRANCH"


### PR DESCRIPTION
*Description:*  This PR fixes an AppSec finding related to script injection vulnerabilities in the `aggregate-prs.yml` GitHub Actions workflow. The original fix was pulled from the staging repo: https://github.com/aws-neuron/aws-neuron-samples-staging/commit/72a77470c01ba4c800a8926ad20a02c0af2267a1

**Changes:**
- Replaced direct usage of `github.event.*` values with intermediate environment variables to prevent script injection attacks. Ref: https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
- Added proper quoting around shell variables to prevent word splitting and glob expansion
- Applied fixes to both affected workflow steps:
  - "Merge for Labeled Event" 
  - "Check PR Labels and Merge for New Commit Events"

*Issue #, sim, or t.corp if available:* https://t.corp.amazon.com/V1931148081/overview

* Link to RTD for my changes: N/A (Github Actions workflow change) 

* Submitter Checklist        
    * Tested on : Changes tested locally - workflow syntax is valid
    * Since this is a simple change to the Github Actions workflow, none of the below apply. 
    *  I've completely filled out the form above!
       **(MANDATORY) PR needs test run output
        
            * I have provided the output with expected metrics in a metrics.json file
       
            * I have attached metric.json in the PR

            * I have attached golden_step_loss.txt 
       
            * I have added screen shot of plotted loss curve
       
        *  (If applicable) I've automated a test to safeguard my changes from regression.
        *  (If applicable) I've posted test collateral to prove my change was effective and not harmful.
        *  (If applicable) I've added someone from QA to the list of reviewers. Do this if you didn't make an automated test or feel it's appropriate for another reason.
        *  (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.
* Reviewer Checklist
        *  I've verified the changes render correctly on RTD (link above)
        *  I've ensured the submitter completed the form
        *  (If appropriate) I've verified the metrics.json file provided by the submitter




